### PR TITLE
Fix for Training

### DIFF
--- a/qubo-lifecycle.py
+++ b/qubo-lifecycle.py
@@ -72,10 +72,10 @@ embedding = {1:[1], 2:[2], 3:[3,4]}
 # Map our Ising model onto the embedding
 qubits = list(i for x in embedding.values() for i in x)
 target = nx.cycle_graph(qubits)
-th, tJ0 = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
-# Original embedding's tJ0 has some disordered terms (e.g. (2,1) instead of (1,2))
-# Create an ordered version of tJ0 to fit the quiz question format
-tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ0[key]) for key in tJ0.keys() } 
+th, tJ_disoredered = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
+# Original embedding's tJ_disordered has some disordered terms (e.g. (2,1) instead of (1,2))
+# Create an ordered version of tJ_disordered to fit the quiz question format
+tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ_disordered[key]) for key in tJ_disordered.keys() } 
 
 
 print("\nQMI (unscaled):\n")

--- a/qubo-lifecycle.py
+++ b/qubo-lifecycle.py
@@ -72,7 +72,7 @@ embedding = {1:[1], 2:[2], 3:[3,4]}
 # Map our Ising model onto the embedding
 qubits = list(i for x in embedding.values() for i in x)
 target = nx.cycle_graph(qubits)
-th, tJ_disoredered = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
+th, tJ_disordered = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
 # Original embedding's tJ_disordered has some disordered terms (e.g. (2,1) instead of (1,2))
 # Create an ordered version of tJ_disordered to fit the quiz question format
 tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ_disordered[key]) for key in tJ_disordered.keys() } 

--- a/qubo-lifecycle.py
+++ b/qubo-lifecycle.py
@@ -74,8 +74,9 @@ qubits = list(i for x in embedding.values() for i in x)
 target = nx.cycle_graph(qubits)
 th, tJ0 = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
 # Original embedding's tJ0 has some disordered terms (e.g. (2,1) instead of (1,2))
+# Create an ordered version of tJ0 to fit the quiz question format
 tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ0[key]) for key in tJ0.keys() } 
-# Above line creates an ordered version of tJ0 to fit the quiz question format
+
 
 print("\nQMI (unscaled):\n")
 

--- a/qubo-lifecycle.py
+++ b/qubo-lifecycle.py
@@ -72,7 +72,10 @@ embedding = {1:[1], 2:[2], 3:[3,4]}
 # Map our Ising model onto the embedding
 qubits = list(i for x in embedding.values() for i in x)
 target = nx.cycle_graph(qubits)
-th, tJ = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24)
+th, tJ0 = dwave.embedding.embed_ising(ising_model[0], ising_model[1], embedding, target, chain_strength=24) # Generate the basic embedding 
+# Original embedding's tJ0 has some disordered terms (e.g. (2,1) instead of (1,2))
+tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ0[key]) for key in tJ0.keys() } 
+# Above line creates an ordered version of tJ0 to fit the quiz question format
 
 print("\nQMI (unscaled):\n")
 

--- a/qubo-lifecycle.py
+++ b/qubo-lifecycle.py
@@ -77,7 +77,6 @@ th, tJ_disordered = dwave.embedding.embed_ising(ising_model[0], ising_model[1], 
 # Create an ordered version of tJ_disordered to fit the quiz question format
 tJ={ (key if key[0]<key[1] else (key[1],key[0])):(tJ_disordered[key]) for key in tJ_disordered.keys() } 
 
-
 print("\nQMI (unscaled):\n")
 
 for i in range(1,5):


### PR DESCRIPTION
The tJ dictionary's keys are not ordered (e.g. (2,1) instead of (1,2)) which leads to some confusion on the quiz questions. I reformed the tJ dictionary to be ordered and therefore agree with the quiz questions.